### PR TITLE
Add remote schema support, compile validators & improve logging

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -53,4 +53,5 @@ services:
           host: 192.168.122.64
           port: 2181
       topics:
-        - example
+        example:
+          schema: example

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -27,7 +27,7 @@ function Producer(params) {
  *
  * @example
  * [
- *   { 
+ *   {
  *     topic:       'topicName',
  *     messages:    [ msg, msg, ... ],
  *     partition:   0,
@@ -36,7 +36,7 @@ function Producer(params) {
  *   ...
  * ]
  *
- * @param   {array} messages; the list of messages to send to the queue 
+ * @param   {array} messages; the list of messages to send to the queue
  * @return {object} a promise that resolves to the status of the send
  */
 Producer.prototype.send = function(messages) {
@@ -82,11 +82,15 @@ function KafkaProducer(params) {
 util.inherits(KafkaProducer, Producer);
 
 /** @inheritdoc */
-KafkaProducer.prototype.send = function(messages) {
+KafkaProducer.prototype.send = function(batch) {
     var self = this;
+    // Use JSON serialization
+    batch.messages = batch.messages.map(JSON.stringify);
+    // Enable snappy compression
+    batch.attributes = 2;
     return this.ready.then(function() {
-        self.logger.log('trace/kafka/send', messages);
-        return self.producer.sendAsync(messages);
+        self.logger.log('trace/kafka/send', batch);
+        return self.producer.sendAsync(batch);
     });
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,45 +1,55 @@
 'use strict';
 
-var P      = require('bluebird');
-var avj    = require('ajv');
-var fs     = P.promisifyAll(require('fs'));
-var path   = require('path');
+var P = require('bluebird');
+var ajv = require('ajv')();
+var fs = P.promisifyAll(require('fs'));
+var path = require('path');
+var preq = require('preq');
 
 
 /** @const */
 var SCHEMA_REPO = path.join(__dirname, '../schemas');
 
 
-function schemaPath(topic) {
-    return path.join(SCHEMA_REPO, topic.toLowerCase() + '.js');
+function schemaPath(schema) {
+    return path.join(SCHEMA_REPO, schema.toLowerCase() + '.js');
 }
 
 /**
  * Return a schema object from the registry for a given topic.
  */
-function schemaObj(topic) {
-    return fs.readFileAsync(schemaPath(topic))
-    .then(function(json) {
-        return JSON.parse(json);
-    });
+function loadSchema(schema) {
+    if (/^https?:\/\//.test(schema)) {
+        return preq.get(schema)
+        .then(function(res) {
+            return res.body;
+        });
+    } else {
+        return fs.readFileAsync(schemaPath(schema))
+        .then(function(json) {
+            return JSON.parse(json);
+        });
+    }
 }
 
 /**
  * Return a validator function for our schemas.
  */
-function createValidator(topics) {
-    // XXX: validate that topics is an array
-    var v = avj();
- 
-    return P.each(topics, function(topic) {
-        return schemaObj(topic).then(function(obj) {
-            v.addSchema(obj, topic);
+function createValidators(topics) {
+    var validators = {};
+
+    return P.each(Object.keys(topics), function(name) {
+        var topic = topics[name] || {};
+        // Fall back to the topic name
+        return loadSchema(topic.schema || name)
+        .then(function(schemaObj) {
+            validators[name] = ajv.compile(schemaObj);
         });
     })
-    .then(function() { return v; });
+    .then(function() { return validators; });
 }
 
 
 module.exports = {
-    createValidator: createValidator,
+    createValidators: createValidators,
 };

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -16,10 +16,10 @@ describe('Schema validation', function() {
             {'url': 'http://localhost', 'type': 'unit', 'details': 'house fav'},
         ];
 
-        return schema.createValidator(['example'])
+        return schema.createValidators({ example: { schema: 'example' } })
         .then(function(v) {
             messages.forEach(function(msg, idx) {
-                assert(v.validate('example', msg), 'schema is invalid (index ' + idx + ')');
+                assert(v.example(msg), 'schema is invalid (index ' + idx + ')');
             });
         });
     });
@@ -31,10 +31,10 @@ describe('Schema validation', function() {
             { 'type': 'unit', 'details': 'house fav' },
         ];
 
-        return schema.createValidator(['example'])
+        return schema.createValidators({ example: {} })
         .then(function(v) {
             messages.forEach(function(msg, idx) {
-                assert(!v.validate('example', msg), 'erroneous validation (index ' + idx + ')');
+                assert(!v.example(msg), 'erroneous validation (index ' + idx + ')');
             });
         });
     });


### PR DESCRIPTION
- Change the topic configuration from an array of strings to an object, with
  each topic configured with its own options object.
- Support loading of remote schemas by setting the .schema config property to
  a URL starting with http:// or https://.
- Compile validators for better performance.
- Improve startup error logging. This should probably be incorporated into
  service-template.
