### PR TITLE
Update Travis YAML file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
+
+sudo: false
+
 node_js:
     - "0.10"
-    - "0.11"
     - "0.12"
-    - "iojs"
+    - "iojs-v2.5.0"
 


### PR DESCRIPTION
- test with iojs v2.5
- remove 0.11
- use containers

Note: node 4.2 tests are not used for now, as `snappy` does not build against it yet (cf kesla/node-snappy#77)
