### PR TITLE
Use the 'debian' deploy target

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "domino": "^1.0.19",
     "express": "^4.13.3",
     "js-yaml": "^3.4.3",
-    "kafka-node": "^0.2.27",
+    "kafka-node": "^0.2.29",
     "preq": "^0.4.4",
     "service-runner": "^0.2.12"
   },
@@ -49,7 +49,7 @@
     "swagger-router": "^0.2.0"
   },
   "deploy": {
-    "target": "ubuntu",
+    "target": "debian",
     "dependencies": {
       "_all": []
     }


### PR DESCRIPTION
We will be deploying this service onto Debian Jessie machines, so make sure that's reflected in the package deployment definition.

Also: bump kafka-node's version to 0.2.29
