### PR TITLE
Routes: Skip domain

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -61,10 +61,10 @@ function validateMessages(topic, messages) {
 
 
 /**
- * GET /topics/
+ * GET /v1/topics/
  * Gets the list of available topics to post to
  */
-router.get('/topics/', function(req, res) {
+router.get('/v1/topics/', function(req, res) {
 
     var schemaList = Object.keys(app.schemas);
 
@@ -82,7 +82,11 @@ router.get('/topics/', function(req, res) {
 });
 
 
-router.get('/topics/:name', function(req, res) {
+/**
+ * GET /v1/topics/{name}
+ * Gets the schema associated with a topic
+ */
+router.get('/v1/topics/:name', function(req, res) {
 
     var topic = req.params.name;
 
@@ -101,7 +105,7 @@ router.get('/topics/:name', function(req, res) {
 
 
 /**
- * POST /topics/{name}/
+ * POST /v1/topics/{name}/
  * Enqueue one or more events. Each event needs to conform to the JSON schema
  * associated with this topic.
  */

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -121,7 +121,7 @@ module.exports = function(appObj) {
 
     return {
         path: '/',
-        api_version: 1,
+        skip_domain: true,
         router: router
     };
 };

--- a/test/features/v1/index.js
+++ b/test/features/v1/index.js
@@ -14,9 +14,11 @@ describe('Topic definitions', function() {
 
     before(function () { return server.start(); });
 
+    var uri = server.config.uri + 'v1/topics/';
+
     it('get topics list', function() {
         return preq.get({
-            uri: server.config.uri + 'wwww/v1/topics/'
+            uri: uri
         }).then(function(res) {
             assert.status(res, 200);
             assert.deepEqual(!!res.body.items, true, 'No items returned!');
@@ -25,7 +27,7 @@ describe('Topic definitions', function() {
 
     it('get topic schema', function() {
         return preq.get({
-            uri: server.config.uri + 'wwww/v1/topics/example'
+            uri: uri + 'example'
         }).then(function(res) {
             assert.status(res, 200);
             assert.deepEqual(!!res.body.properties, true);


### PR DESCRIPTION
The URI layout has included the domain. However, the domain is not relevant for the producer side, so do not include it. The new URI now is `http://domain:port/v1/topics/{name}`
