### PR TITLE
Create topics on start-up

### DIFF
--- a/app.js
+++ b/app.js
@@ -168,6 +168,8 @@ function initProducer(app) {
     return queue.getProducer({ conf: app.conf, logger: app.logger })
     .then(function(producer) {
         app.producer = producer;
+        return producer.createTopics(Object.keys(app.schemaValidators));
+    }).then(function() {
         return app;
     });
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -45,6 +45,16 @@ Producer.prototype.sendBatch = function(messages) {
 };
 
 /**
+ * Attempts to create the given topics one by one
+ *
+ * @param {Array} topics; the list of topics to create
+ */
+Producer.prototype.createTopics = function(topics) {
+    throw new Error('not implemented; you must override Producer#createTopics');
+};
+
+
+/**
  * Producer implementation based on Kafka.
  *
  * @extends {Producer}
@@ -104,6 +114,22 @@ KafkaProducer.prototype.sendBatch = function(batch) {
     });
     self.logger.log('trace/kafka/send', { payload: batch });
     return self.producer.sendAsync(batch);
+};
+
+/** @inheritdoc */
+KafkaProducer.prototype.createTopics = function(topics) {
+
+    var self = this;
+
+    if (!Array.isArray(topics)) {
+        topics = [topics];
+    }
+
+    return P.each(topics, function(t) {
+        self.logger.log('info/topic/create', 'Creating topic ' + t);
+        return self.client.createTopicsAsync([t]);
+    });
+
 };
 
 


### PR DESCRIPTION
When the service starts up, we should ensure the topics exist in the queue. Topic creation is idempotent in Kafka, so we can safely just create them without checking if they already exist. This PR does that serially for each defined topic.

Note: depends on PR #7 
