### PR TITLE
Routes: Add routes exposing the list of topics and their schemas

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,16 +143,16 @@ function initApp(options) {
 }
 
 /**
- * Initializes a new JSON schema validator according to the configured
- * topic list, and stores it in the app objects 'schemaValidators' attribute.
+ * Initializes the list of schema definitions for the configured topic
+ * list, and stores it in the app object's 'schemas' attribute.
  *
  * @param   {object} app; the application object to attach the validator to
  * @returns {object} a promise that resolves to the app object
  */
-function initSchemaValidators(app) {
-    return schema.createValidators(app.conf.topics)
-    .then(function(v) {
-        app.schemaValidators = v;
+function initSchemas(app) {
+    return schema.getSchemas(app.conf.topics)
+    .then(function(s) {
+        app.schemas = s;
         return app;
     });
 }
@@ -161,7 +161,7 @@ function initSchemaValidators(app) {
  * Initializess a new Producer according to the configured provider, and stores
  * it in the app objects 'producer' attribute.
  *
- * @param   {object} app; the application object to attach the validator to
+ * @param   {object} app; the application object to attach the schemas to
  * @returns {object} a promise that resolves to the app object
  */
 function initProducer(app) {
@@ -258,7 +258,7 @@ module.exports = function(options) {
         app = appObj;
         return app;
     })
-    .then(initSchemaValidators)
+    .then(initSchemas)
     .then(initProducer)
     .then(loadRoutes)
     .then(createServer)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -40,23 +40,28 @@ function loadSchema(schema) {
 }
 
 /**
- * Return a validator function for our schemas.
+ * Gets the schema definitions and their validator functions
+ *
+ * @param {object} topics; the object containing the topics to get as keys
  */
-function createValidators(topics) {
-    var validators = {};
+function getSchemas(topics) {
+    var schemas = {};
 
     return P.each(Object.keys(topics), function(name) {
         var topic = topics[name] || {};
         // Fall back to the topic name
         return loadSchema(topic.schema || name)
         .then(function(schemaObj) {
-            validators[name] = ajv.compile(schemaObj);
+            schemas[name] = {
+                definition: schemaObj,
+                validator: ajv.compile(schemaObj)
+            };
         });
     })
-    .then(function() { return validators; });
+    .then(function() { return schemas; });
 }
 
 
 module.exports = {
-    createValidators: createValidators,
+    getSchemas: getSchemas
 };

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -26,7 +26,7 @@ var app;
  */
 function validateMessages(topic, messages) {
     // Check if we have a validator for this topic
-    var validate = app.schemaValidators[topic];
+    var validate = app.schemas[topic] && app.schemas[topic].validator;
     if (!validate) {
         throw new HTTPError({
             status: 400,
@@ -58,6 +58,46 @@ function validateMessages(topic, messages) {
         messages: messages
     };
 }
+
+
+/**
+ * GET /topics/
+ * Gets the list of available topics to post to
+ */
+router.get('/topics/', function(req, res) {
+
+    var schemaList = Object.keys(app.schemas);
+
+    if (!schemaList.length) {
+        throw new HTTPError({
+            status: 404,
+            type: 'not_found',
+            title: 'No topic',
+            detail: 'No topic has been defined'
+        });
+    }
+
+    res.status(200).json({ items: schemaList }).end();
+
+});
+
+
+router.get('/topics/:name', function(req, res) {
+
+    var topic = req.params.name;
+
+    if (!app.schemas[topic]) {
+        throw new HTTPError({
+            status: 404,
+            type: 'not_found',
+            title: 'No such topic',
+            detail: 'The topic "' + topic + '" does not exist'
+        });
+    }
+
+    res.status(200).json(app.schemas[topic].definition).end();
+
+});
 
 
 /**

--- a/test/features/v1/index.js
+++ b/test/features/v1/index.js
@@ -10,14 +10,29 @@ var assert = require('../../utils/assert.js');
 var server = require('../../utils/server.js');
 
 
-describe('stub', function() {
-
-    this.timeout(20000);
+describe('Topic definitions', function() {
 
     before(function () { return server.start(); });
 
-    it('should implement an actual test', function() {
+    it('get topics list', function() {
+        return preq.get({
+            uri: server.config.uri + 'wwww/v1/topics/'
+        }).then(function(res) {
+            assert.status(res, 200);
+            assert.deepEqual(!!res.body.items, true, 'No items returned!');
+        });
+    });
 
+    it('get topic schema', function() {
+        return preq.get({
+            uri: server.config.uri + 'wwww/v1/topics/example'
+        }).then(function(res) {
+            assert.status(res, 200);
+            assert.deepEqual(!!res.body.properties, true);
+            assert.deepEqual(!!res.body.title, true);
+            assert.deepEqual(!!res.body.required, true);
+            assert.deepEqual(!!res.body.type, true);
+        });
     });
 
 });

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -16,10 +16,10 @@ describe('Schema validation', function() {
             {'url': 'http://localhost', 'type': 'unit', 'details': 'house fav'},
         ];
 
-        return schema.createValidators({ example: { schema: 'example' } })
-        .then(function(v) {
+        return schema.getSchemas({ example: { schema: 'example' } })
+        .then(function(s) {
             messages.forEach(function(msg, idx) {
-                assert(v.example(msg), 'schema is invalid (index ' + idx + ')');
+                assert(s.example.validator(msg), 'schema is invalid (index ' + idx + ')');
             });
         });
     });
@@ -31,10 +31,10 @@ describe('Schema validation', function() {
             { 'type': 'unit', 'details': 'house fav' },
         ];
 
-        return schema.createValidators({ example: {} })
-        .then(function(v) {
+        return schema.getSchemas({ example: {} })
+        .then(function(s) {
             messages.forEach(function(msg, idx) {
-                assert(!v.example(msg), 'erroneous validation (index ' + idx + ')');
+                assert(!s.example.validator(msg), 'erroneous validation (index ' + idx + ')');
             });
         });
     });


### PR DESCRIPTION
This PR adds two new routes:
- `GET /topics/`
- `GET /topics/{name}`

The former returns the list of available topics, while the latter returns the given topic's JSON schema definition.
